### PR TITLE
SDT-173: Remove int test JUnit4 dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,13 +120,11 @@ dependencies {
 
     testImplementation libraries.junit5
     testImplementation group: 'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: '1.4.0'
-    testImplementation group: 'org.easymock', name: 'easymock', version: '5.0.1'
     testImplementation group: 'org.jdom', name: 'jdom2', version: '2.0.6.1'
     testImplementation 'org.mockito:mockito-core:5.2.0'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.11.1'
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
     testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.9'
-    testImplementation group: 'org.dbunit', name: 'dbunit', version: '2.7.3'
     testImplementation 'org.springframework:spring-test:6.0.7'
     testImplementation group: 'xerces', name: 'xercesImpl', version: '2.12.2'
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: log4jVersion
@@ -187,13 +185,11 @@ subprojects {
 
         testImplementation libraries.junit5
         testImplementation group: 'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: '1.4.0'
-        testImplementation group: 'org.easymock', name: 'easymock', version: '5.0.1'
         testImplementation group: 'org.jdom', name: 'jdom2', version: '2.0.6.1'
         testImplementation 'org.mockito:mockito-core:5.2.0'
         testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.11.1'
         testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
         testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.9'
-        testImplementation group: 'org.dbunit', name: 'dbunit', version: '2.7.3'
         testImplementation 'org.springframework:spring-test:6.0.7'
         testImplementation group: 'xerces', name: 'xercesImpl', version: '2.12.2'
         testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: log4jVersion

--- a/utils/src/integ-test/java/uk/gov/moj/sdt/test/utils/AbstractIntegrationTest.java
+++ b/utils/src/integ-test/java/uk/gov/moj/sdt/test/utils/AbstractIntegrationTest.java
@@ -35,18 +35,17 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
 
 import java.lang.reflect.Method;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Implementation of the integration test for BulkSubmissionService.
  *
  * @author Manoj kulkarni
  */
-public abstract class AbstractIntegrationTest extends AbstractTransactionalJUnit4SpringContextTests {
+public abstract class AbstractIntegrationTest {
 
     /**
      * Logger object.
@@ -66,8 +65,9 @@ public abstract class AbstractIntegrationTest extends AbstractTransactionalJUnit
          *
          * @param description Information about the test.
          */
+        @Override
         protected void starting(final Description description) {
-            LOGGER.info("Start Test: " + description.getClassName() + "." + description.getMethodName() + ".");
+            LOGGER.info("Start Test: {}.{}.", description.getClassName(), description.getMethodName());
         }
     };
 
@@ -94,10 +94,10 @@ public abstract class AbstractIntegrationTest extends AbstractTransactionalJUnit
             method.setAccessible(true);
         } catch (final SecurityException e) {
             LOGGER.debug(e.getMessage());
-            assertTrue("SecurityException please debug test", false);
+            fail("SecurityException please debug test");
         } catch (final NoSuchMethodException e) {
             LOGGER.debug(e.getMessage());
-            assertTrue("NoSuchMethodException please debug test", false);
+            fail("NoSuchMethodException please debug test");
         }
         return method;
     }


### PR DESCRIPTION
### Jira link (if applicable)
SDT-173 (https://tools.hmcts.net/jira/browse/SDT-173)


### Change description ###
Amended AbstractIntegrationTest so that it no longer utilises Spring JUnit4 context.  Also tied up class to remove a few warnings.

Removed easymock and dbunit dependencies from build.gradle as they are no longer used.

