### PR TITLE
SDT-181: Replace remaining JUnit4 references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ java {
 }
 
 ext {
-    lombokVersion = '1.18.24'
     junitVersion           = '5.7.2'
     junitPlatformVersion   = '1.7.2'
     log4jVersion = '2.20.0'
@@ -93,11 +92,6 @@ bootJar {
 }
 
 dependencies {
-
-    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-    implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-    testImplementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:30.0-jre'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4jVersion
@@ -123,8 +117,6 @@ dependencies {
     testImplementation group: 'org.jdom', name: 'jdom2', version: '2.0.6.1'
     testImplementation 'org.mockito:mockito-core:5.2.0'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.11.1'
-    testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
-    testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.9'
     testImplementation 'org.springframework:spring-test:6.0.7'
     testImplementation group: 'xerces', name: 'xercesImpl', version: '2.12.2'
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: log4jVersion
@@ -148,6 +140,7 @@ subprojects {
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'com.github.ben-manes.versions'
+    apply plugin: 'io.freefair.lombok'
 
     configurations {
         testUnitImplementation.extendsFrom testImplementation
@@ -158,11 +151,6 @@ subprojects {
     }
 
     dependencies {
-
-        annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-        implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-        testImplementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-
         // This dependency is used internally, and not exposed to consumers on their own compile classpath.
         implementation 'com.google.guava:guava:30.0-jre'
         implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4jVersion
@@ -188,8 +176,6 @@ subprojects {
         testImplementation group: 'org.jdom', name: 'jdom2', version: '2.0.6.1'
         testImplementation 'org.mockito:mockito-core:5.2.0'
         testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.11.1'
-        testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
-        testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.9'
         testImplementation 'org.springframework:spring-test:6.0.7'
         testImplementation group: 'xerces', name: 'xercesImpl', version: '2.12.2'
         testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: log4jVersion

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,15 +2,19 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
   <!--Please add all the false positives under the below section-->
+  <!--
   <suppress>
     <notes>False Positives</notes>
   </suppress>
+  -->
   <!--End of false positives section -->
 
   <!--Please add all the temporary suppression under the below section-->
+  <!--
   <suppress>
     <notes>Temporary Suppressions</notes>
   </suppress>
+  -->
   <!--End of temporary suppression section -->
 
 </suppressions>

--- a/domain/src/unit-test/java/uk/gov/moj/sdt/domain/visitor/AbstractDomainObjectVisitorTest.java
+++ b/domain/src/unit-test/java/uk/gov/moj/sdt/domain/visitor/AbstractDomainObjectVisitorTest.java
@@ -1,10 +1,8 @@
 package uk.gov.moj.sdt.domain.visitor;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.moj.sdt.domain.api.IBulkCustomer;
 import uk.gov.moj.sdt.domain.api.IBulkFeedbackRequest;
@@ -17,79 +15,91 @@ import uk.gov.moj.sdt.domain.api.ITargetApplication;
 import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
 import uk.gov.moj.sdt.utils.visitor.Tree;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class AbstractDomainObjectVisitorTest extends AbstractSdtUnitTestBase {
 
-    public AbstractDomainObjectVisitor abstractDomainObjectVisitor;
+    private AbstractDomainObjectVisitor abstractDomainObjectVisitor;
 
+    private static final String UNEXPECTED_EXCEPTION = "Unexpected exception thrown";
     private static final String EXPECTED_MESSAGE =
-        "Missing visitor implementation: this method should never be called.";
+            "Missing visitor implementation: this method should never be called.";
+    private static final String UNEXPECTED_EXCEPTION_MESSAGE =
+            "Exception has unexpected message";
 
     @Mock
     Tree mockTree;
 
-    @BeforeEach
     @Override
-    public void setUp() {
+    protected void setUpLocalTests() {
         abstractDomainObjectVisitor = new AbstractDomainObjectVisitor() {};
     }
 
     @Test
     void testVisitBulkCustomerThrows() {
-        IBulkCustomer mockBulkCustomer = Mockito.mock(IBulkCustomer.class);
-        assertThrows(EXPECTED_MESSAGE, UnsupportedOperationException.class,
-                     () -> abstractDomainObjectVisitor.visit(mockBulkCustomer, mockTree));
+        IBulkCustomer mockBulkCustomer = mock(IBulkCustomer.class);
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                     () -> abstractDomainObjectVisitor.visit(mockBulkCustomer, mockTree), UNEXPECTED_EXCEPTION);
+        assertEquals(EXPECTED_MESSAGE, exception.getMessage(), UNEXPECTED_EXCEPTION_MESSAGE);
     }
 
     @Test
     void testVisitBulkSubmissionThrows() {
-        IBulkSubmission mockBulkSubmission = Mockito.mock(IBulkSubmission.class);
-        assertThrows(EXPECTED_MESSAGE, UnsupportedOperationException.class,
-                     () -> abstractDomainObjectVisitor.visit(mockBulkSubmission, mockTree));
+        IBulkSubmission mockBulkSubmission = mock(IBulkSubmission.class);
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                     () -> abstractDomainObjectVisitor.visit(mockBulkSubmission, mockTree), UNEXPECTED_EXCEPTION);
+        assertEquals(EXPECTED_MESSAGE, exception.getMessage(), UNEXPECTED_EXCEPTION_MESSAGE);
     }
 
     @Test
     void testVisitServiceTypeThrows() {
-        IServiceType mockServiceType = Mockito.mock(IServiceType.class);
-        assertThrows(EXPECTED_MESSAGE, UnsupportedOperationException.class,
-                     () -> abstractDomainObjectVisitor.visit(mockServiceType, mockTree));
+        IServiceType mockServiceType = mock(IServiceType.class);
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                     () -> abstractDomainObjectVisitor.visit(mockServiceType, mockTree), UNEXPECTED_EXCEPTION);
+        assertEquals(EXPECTED_MESSAGE, exception.getMessage(), UNEXPECTED_EXCEPTION_MESSAGE);
     }
 
     @Test
     void testVisitTargetApplicationThrows() {
-        ITargetApplication mockTargetApplication = Mockito.mock(ITargetApplication.class);
-        assertThrows(EXPECTED_MESSAGE, UnsupportedOperationException.class,
-                     () -> abstractDomainObjectVisitor.visit(mockTargetApplication, mockTree));
+        ITargetApplication mockTargetApplication = mock(ITargetApplication.class);
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                     () -> abstractDomainObjectVisitor.visit(mockTargetApplication, mockTree), UNEXPECTED_EXCEPTION);
+        assertEquals(EXPECTED_MESSAGE, exception.getMessage(), UNEXPECTED_EXCEPTION_MESSAGE);
     }
 
     @Test
     void testVisitIndividualRequestThrows() {
-        IIndividualRequest mockIndividualRequest = Mockito.mock(IIndividualRequest.class);
-        assertThrows(EXPECTED_MESSAGE, UnsupportedOperationException.class,
-                     () -> abstractDomainObjectVisitor.visit(mockIndividualRequest, mockTree));
+        IIndividualRequest mockIndividualRequest = mock(IIndividualRequest.class);
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                     () -> abstractDomainObjectVisitor.visit(mockIndividualRequest, mockTree), UNEXPECTED_EXCEPTION);
+        assertEquals(EXPECTED_MESSAGE, exception.getMessage(), UNEXPECTED_EXCEPTION_MESSAGE);
     }
 
     @Test
     void testVisitSubmitQueryRequestThrows() {
-        ISubmitQueryRequest mockSubmitQueryRequest = Mockito.mock(ISubmitQueryRequest.class);
-        assertThrows(EXPECTED_MESSAGE, UnsupportedOperationException.class,
-                     () -> abstractDomainObjectVisitor.visit(mockSubmitQueryRequest, mockTree));
+        ISubmitQueryRequest mockSubmitQueryRequest = mock(ISubmitQueryRequest.class);
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                     () -> abstractDomainObjectVisitor.visit(mockSubmitQueryRequest, mockTree), UNEXPECTED_EXCEPTION);
+        assertEquals(EXPECTED_MESSAGE, exception.getMessage(), UNEXPECTED_EXCEPTION_MESSAGE);
     }
 
     @Test
     void testVisitBulkFeedbackRequestThrows() {
-        IBulkFeedbackRequest mockBulkFeedbackRequest = Mockito.mock(IBulkFeedbackRequest.class);
-        assertThrows(EXPECTED_MESSAGE, UnsupportedOperationException.class,
-                     () -> abstractDomainObjectVisitor.visit(mockBulkFeedbackRequest, mockTree));
+        IBulkFeedbackRequest mockBulkFeedbackRequest = mock(IBulkFeedbackRequest.class);
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                     () -> abstractDomainObjectVisitor.visit(mockBulkFeedbackRequest, mockTree), UNEXPECTED_EXCEPTION);
+        assertEquals(EXPECTED_MESSAGE, exception.getMessage(), UNEXPECTED_EXCEPTION_MESSAGE);
     }
 
     @Test
     void testVisitErrorLogThrows() {
-        IErrorLog mockErrorLog = Mockito.mock(IErrorLog.class);
-        assertThrows(EXPECTED_MESSAGE, UnsupportedOperationException.class,
-                     () -> abstractDomainObjectVisitor.visit(mockErrorLog, mockTree));
+        IErrorLog mockErrorLog = mock(IErrorLog.class);
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                     () -> abstractDomainObjectVisitor.visit(mockErrorLog, mockTree), UNEXPECTED_EXCEPTION);
+        assertEquals(EXPECTED_MESSAGE, exception.getMessage(), UNEXPECTED_EXCEPTION_MESSAGE);
     }
 
 }

--- a/handlers/src/unit-test/java/uk/gov/moj/sdt/handlers/WsReadBulkFeedbackRequestHandlerTest.java
+++ b/handlers/src/unit-test/java/uk/gov/moj/sdt/handlers/WsReadBulkFeedbackRequestHandlerTest.java
@@ -1,12 +1,10 @@
 package uk.gov.moj.sdt.handlers;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 import uk.gov.moj.sdt.domain.api.IBulkFeedbackRequest;
@@ -16,14 +14,19 @@ import uk.gov.moj.sdt.transformers.api.ITransformer;
 import uk.gov.moj.sdt.utils.mbeans.SdtMetricsMBean;
 import uk.gov.moj.sdt.utils.visitor.VisitableTreeWalker;
 import uk.gov.moj.sdt.validators.exception.CustomerNotFoundException;
+import uk.gov.moj.sdt.ws._2013.sdt.baseschema.ErrorType;
+import uk.gov.moj.sdt.ws._2013.sdt.baseschema.StatusCodeType;
+import uk.gov.moj.sdt.ws._2013.sdt.baseschema.StatusType;
 import uk.gov.moj.sdt.ws._2013.sdt.bulkfeedbackrequestschema.BulkFeedbackRequestType;
 import uk.gov.moj.sdt.ws._2013.sdt.bulkfeedbackrequestschema.HeaderType;
 import uk.gov.moj.sdt.ws._2013.sdt.bulkfeedbackresponseschema.BulkFeedbackResponseType;
-import uk.gov.moj.sdt.ws._2013.sdt.bulkfeedbackresponseschema.BulkRequestStatusType;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.*;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class WsReadBulkFeedbackRequestHandlerTest {
@@ -53,7 +56,7 @@ class WsReadBulkFeedbackRequestHandlerTest {
 
     @BeforeEach
     public void setUp() {
-        wsReadBulkFeedbackRequestHandler = Mockito.spy(new WsReadBulkFeedbackRequestHandler(
+        wsReadBulkFeedbackRequestHandler = spy(new WsReadBulkFeedbackRequestHandler(
             mockBulkFeedbackService, mockTransformer));
         wsReadBulkFeedbackRequestHandler.setBulkFeedbackService(mockBulkFeedbackService);
         wsReadBulkFeedbackRequestHandler.setTransformer(mockTransformer);
@@ -73,38 +76,37 @@ class WsReadBulkFeedbackRequestHandlerTest {
 
         BulkFeedbackResponseType result;
 
-        try (MockedStatic<VisitableTreeWalker> mockStaticVisitableTreeWalker = Mockito.mockStatic(VisitableTreeWalker.class)) {
+        try (MockedStatic<VisitableTreeWalker> mockStaticVisitableTreeWalker = mockStatic(VisitableTreeWalker.class)) {
             mockStaticVisitableTreeWalker.when(() -> VisitableTreeWalker.walk(mockBulkFeedbackRequest, "Validator"))
                 .then((Answer<Void>) invocation -> null);
 
             result = wsReadBulkFeedbackRequestHandler.getBulkFeedback(mockBulkFeedbackRequestType);
 
             verify(mockTransformer).transformJaxbToDomain(mockBulkFeedbackRequestType);
-            verifyStatic(VisitableTreeWalker.class);
-            VisitableTreeWalker.walk(mockBulkFeedbackRequest, "Validator");
+            mockStaticVisitableTreeWalker.verify(() -> VisitableTreeWalker.walk(mockBulkFeedbackRequest, "Validator"));
             verify(mockBulkFeedbackService).getBulkFeedback(mockBulkFeedbackRequest);
             verify(mockTransformer).transformDomainToJaxb(mockBulkSubmission);
         }
 
         testMetrics();
-        Assertions.assertEquals(mockBulkFeedbackResponseType, result);
+        assertEquals(mockBulkFeedbackResponseType, result);
     }
 
     @Test
-    public void testGetBulkFeedbackThrowsAbstractBusinessException() throws Exception {
+    public void testGetBulkFeedbackThrowsAbstractBusinessException() {
         CustomerNotFoundException exception = new CustomerNotFoundException("MOCK_CODE", "MOCK_DESCRIPTION");
 
         when(mockTransformer.transformJaxbToDomain(mockBulkFeedbackRequestType))
             .thenThrow(exception);
 
-        wsReadBulkFeedbackRequestHandler.getBulkFeedback(mockBulkFeedbackRequestType);
+        BulkFeedbackResponseType bulkFeedbackResponseType =
+                wsReadBulkFeedbackRequestHandler.getBulkFeedback(mockBulkFeedbackRequestType);
 
-        verifyPrivate(wsReadBulkFeedbackRequestHandler)
-            .invoke(
-                "handleBusinessException",
-                any(CustomerNotFoundException.class),
-                any(BulkRequestStatusType.class)
-            );
+        StatusType statusType = bulkFeedbackResponseType.getBulkRequestStatus().getStatus();
+        assertEquals(StatusCodeType.ERROR, statusType.getCode(), "BulkFeedback response has unexpected status code");
+        ErrorType errorType = statusType.getError();
+        assertEquals("MOCK_CODE", errorType.getCode(), "Status error has unexpected code");
+        assertEquals("MOCK_DESCRIPTION", errorType.getDescription(), "Status error has unexpected description");
 
         testMetrics();
     }
@@ -112,7 +114,7 @@ class WsReadBulkFeedbackRequestHandlerTest {
     private void testMetrics() {
         String expectedBulkFeedbackCount = "count[1]";
 
-        Assertions.assertTrue(SdtMetricsMBean.getMetrics().getBulkFeedbackStats().contains(expectedBulkFeedbackCount));
-        Assertions.assertEquals(1, SdtMetricsMBean.getMetrics().getActiveBulkCustomers());
+        assertTrue(SdtMetricsMBean.getMetrics().getBulkFeedbackStats().contains(expectedBulkFeedbackCount));
+        assertEquals(1, SdtMetricsMBean.getMetrics().getActiveBulkCustomers());
     }
 }

--- a/handlers/src/unit-test/java/uk/gov/moj/sdt/handlers/WsReadSubmitQueryHandlerTest.java
+++ b/handlers/src/unit-test/java/uk/gov/moj/sdt/handlers/WsReadSubmitQueryHandlerTest.java
@@ -1,12 +1,10 @@
 package uk.gov.moj.sdt.handlers;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 import uk.gov.moj.sdt.domain.api.ISubmitQueryRequest;
@@ -15,13 +13,20 @@ import uk.gov.moj.sdt.transformers.api.ITransformer;
 import uk.gov.moj.sdt.utils.mbeans.SdtMetricsMBean;
 import uk.gov.moj.sdt.utils.visitor.VisitableTreeWalker;
 import uk.gov.moj.sdt.validators.exception.CustomerNotFoundException;
+import uk.gov.moj.sdt.ws._2013.sdt.baseschema.ErrorType;
+import uk.gov.moj.sdt.ws._2013.sdt.baseschema.StatusCodeType;
+import uk.gov.moj.sdt.ws._2013.sdt.baseschema.StatusType;
 import uk.gov.moj.sdt.ws._2013.sdt.submitqueryrequestschema.HeaderType;
 import uk.gov.moj.sdt.ws._2013.sdt.submitqueryrequestschema.SubmitQueryRequestType;
 import uk.gov.moj.sdt.ws._2013.sdt.submitqueryresponseschema.SubmitQueryResponseType;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.*;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class WsReadSubmitQueryHandlerTest {
@@ -48,7 +53,7 @@ class WsReadSubmitQueryHandlerTest {
 
     @BeforeEach
     public void setUp() {
-        wsReadSubmitQueryHandler = Mockito.spy(new WsReadSubmitQueryHandler(
+        wsReadSubmitQueryHandler = spy(new WsReadSubmitQueryHandler(
             mockSubmitQueryService, mockTransformer));
         wsReadSubmitQueryHandler.setSubmitQueryService(mockSubmitQueryService);
         wsReadSubmitQueryHandler.setTransformer(mockTransformer);
@@ -70,44 +75,41 @@ class WsReadSubmitQueryHandlerTest {
 
         SubmitQueryResponseType result;
 
-        try (MockedStatic<VisitableTreeWalker> mockStaticVisitableTreeWalker = Mockito.mockStatic(VisitableTreeWalker.class)) {
+        try (MockedStatic<VisitableTreeWalker> mockStaticVisitableTreeWalker = mockStatic(VisitableTreeWalker.class)) {
             mockStaticVisitableTreeWalker.when(() -> VisitableTreeWalker.walk(mockSubmitQueryRequest, "Validator"))
                 .then((Answer<Void>) invocation -> null);
 
             result = wsReadSubmitQueryHandler.submitQuery(mockSubmitQueryRequestType);
 
-            verifyStatic(VisitableTreeWalker.class);
-            VisitableTreeWalker.walk(mockSubmitQueryRequest, "Validator");
+            mockStaticVisitableTreeWalker.verify(() -> VisitableTreeWalker.walk(mockSubmitQueryRequest, "Validator"));
 
             verify(mockSubmitQueryService).submitQuery(mockSubmitQueryRequest);
-
         }
 
         String expectedSubmitQueryCount = "count[1]";
-        Assertions.assertTrue(SdtMetricsMBean.getMetrics().getSubmitQueryStats().contains(expectedSubmitQueryCount));
-        Assertions.assertNotNull(result);
-        Assertions.assertEquals(mockSubmitQueryResponseType, result);
+        assertTrue(SdtMetricsMBean.getMetrics().getSubmitQueryStats().contains(expectedSubmitQueryCount));
+        assertNotNull(result);
+        assertEquals(mockSubmitQueryResponseType, result);
     }
 
     @Test
-    public void testSubmitQueryThrowsAbstractBusinessException() throws Exception {
+    public void testSubmitQueryThrowsAbstractBusinessException() {
 
         CustomerNotFoundException exception = new CustomerNotFoundException("MOCK_CODE", "MOCK_DESCRIPTION");
 
         when(mockTransformer.transformJaxbToDomain(mockSubmitQueryRequestType))
             .thenThrow(exception);
 
-        wsReadSubmitQueryHandler.submitQuery(mockSubmitQueryRequestType);
+        SubmitQueryResponseType submitQueryResponseType =
+                wsReadSubmitQueryHandler.submitQuery(mockSubmitQueryRequestType);
 
-        verifyPrivate(wsReadSubmitQueryHandler)
-            .invoke(
-                "handleBusinessException",
-                any(CustomerNotFoundException.class),
-                any(SubmitQueryResponseType.class)
-            );
-
+        StatusType statusType = submitQueryResponseType.getStatus();
+        assertEquals(StatusCodeType.ERROR, statusType.getCode(), "SubmitQuery response has unexpected status code");
+        ErrorType errorType = statusType.getError();
+        assertEquals("MOCK_CODE", errorType.getCode(), "Status error has unexpected code");
+        assertEquals("MOCK_DESCRIPTION", errorType.getDescription(), "Status error has unexpected description");
 
         String expectedSubmitQueryCount = "count[1]";
-        Assertions.assertTrue(SdtMetricsMBean.getMetrics().getSubmitQueryStats().contains(expectedSubmitQueryCount));
+        assertTrue(SdtMetricsMBean.getMetrics().getSubmitQueryStats().contains(expectedSubmitQueryCount));
     }
 }

--- a/handlers/src/unit-test/java/uk/gov/moj/sdt/handlers/WsUpdateItemHandlerTest.java
+++ b/handlers/src/unit-test/java/uk/gov/moj/sdt/handlers/WsUpdateItemHandlerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.moj.sdt.handlers;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,8 +13,11 @@ import uk.gov.moj.sdt.ws._2013.sdt.individualupdaterequestschema.HeaderType;
 import uk.gov.moj.sdt.ws._2013.sdt.individualupdaterequestschema.UpdateRequestType;
 import uk.gov.moj.sdt.ws._2013.sdt.individualupdateresponseschema.UpdateResponseType;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class WsUpdateItemHandlerTest {
@@ -67,9 +69,9 @@ class WsUpdateItemHandlerTest {
 
         String expected = "count[1]";
 
-        Assertions.assertTrue(SdtMetricsMBean.getMetrics().getStatusUpdateStats().contains(expected));
-        Assertions.assertNotNull(result);
-        Assertions.assertEquals(mockUpdateResponseType, result);
+        assertTrue(SdtMetricsMBean.getMetrics().getStatusUpdateStats().contains(expected));
+        assertNotNull(result);
+        assertEquals(mockUpdateResponseType, result);
     }
 
 }

--- a/utils/src/integ-test/java/uk/gov/moj/sdt/test/utils/AbstractIntegrationTest.java
+++ b/utils/src/integ-test/java/uk/gov/moj/sdt/test/utils/AbstractIntegrationTest.java
@@ -30,9 +30,6 @@
  * $LastChangedBy: $ */
 package uk.gov.moj.sdt.test.utils;
 
-import org.junit.Rule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,25 +48,6 @@ public abstract class AbstractIntegrationTest {
      * Logger object.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractIntegrationTest.class);
-
-    /**
-     * Watcher to detect current test name.
-     */
-    // CHECKSTYLE:OFF
-    @Rule
-    public TestWatcher watcher = new TestWatcher() {
-        // CHECKSTYLE:ON
-
-        /**
-         * Method called whenever JUnit starts a test.
-         *
-         * @param description Information about the test.
-         */
-        @Override
-        protected void starting(final Description description) {
-            LOGGER.info("Start Test: {}.{}.", description.getClassName(), description.getMethodName());
-        }
-    };
 
     /**
      * Retrieve a field in its accessible state.


### PR DESCRIPTION
### Jira link (if applicable)
SDT-181 (https://tools.hmcts.net/jira/browse/SDT-181)


### Change description ###
- Removed JUnit4 TestWatcher setup from AbstractIntegrationTest.  This only logged the start of a test which doesn't really offer any benefit.  The same code was removed from the AbstractSdtUnitTestBase class in an earlier pull request.
- Replaced assertThrows() in AbstractDomainObjectVisitorTest with JUnit5 equivalent.  Changed tests so that they check message in returned exception - this was intended but not implemented correctly.
- Changed HandlerTest classes to replace powermock with Mockito.
- Removed powermock dependencies from build.gradle.  These included the last remaining JUnit4 dependency.
- build.gradle had both plugin and non-plugin lombok configuration.  Only one of these is needed, so removed non-plugin lombok configuration.
- Commented out empty suppress elements in suppressions.xml to prevent failure when dependency check is run.  Elements will be uncommented when suppressions need to be added to them.


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
