### PR TITLE
SDT-186: Change log4j dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,8 +210,7 @@ dependencies {
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:30.1.1-jre'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4jVersion
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: log4jVersion
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: log4jVersion
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4jVersion
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
     implementation group: 'org.springframework', name: 'spring-jms', version: '5.3.31'
     implementation group: 'org.apache.cxf', name: 'cxf-spring-boot-starter-jaxws', version: cxfVersion
@@ -236,7 +235,7 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.12.4'
     testImplementation 'org.springframework:spring-test:6.1.3'
     testImplementation group: 'xerces', name: 'xercesImpl', version: '2.12.2'
-    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: log4jVersion
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4jVersion
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude group: 'junit', module: 'junit'
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
@@ -270,8 +269,7 @@ subprojects {
         // This dependency is used internally, and not exposed to consumers on their own compile classpath.
         implementation 'com.google.guava:guava:30.1.1-jre'
         implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4jVersion
-        implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: log4jVersion
-        implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: log4jVersion
+        implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4jVersion
         implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
         implementation group: 'org.springframework', name: 'spring-jms', version: '5.3.31'
         implementation group: 'org.apache.cxf', name: 'cxf-spring-boot-starter-jaxws', version: cxfVersion
@@ -296,7 +294,7 @@ subprojects {
         testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.12.4'
         testImplementation 'org.springframework:spring-test:6.1.3'
         testImplementation group: 'xerces', name: 'xercesImpl', version: '2.12.2'
-        testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: log4jVersion
+        testImplementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4jVersion
         testImplementation("org.springframework.boot:spring-boot-starter-test") {
             exclude group: 'junit', module: 'junit'
             exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'


### PR DESCRIPTION
### Jira link (if applicable)
SDT-186 (https://tools.hmcts.net/jira/browse/SDT-186)

### Change description ###
Removed log4j-core dependency from build.gradle and replaced log4j-slf4j2-impl dependency with log4j-to-slf4j.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
