### PR TITLE
SDT-223: Reorder bulk feedback responseType attributes

### DIFF
--- a/producers-api/src/main/resources/xsd/RequestBulkFeedback/BulkFeedbackResponse.xsd
+++ b/producers-api/src/main/resources/xsd/RequestBulkFeedback/BulkFeedbackResponse.xsd
@@ -36,8 +36,8 @@
             </xs:element>
             <xs:element name="status" type="base:individualStatusType"/>
         </xs:sequence>
-        <xs:attribute name="requestType" type="base:requestTypeType" use="required"/>
         <xs:attribute name="requestId" type="base:requestIdType" use="required"/>
+        <xs:attribute name="requestType" type="base:requestTypeType" use="required"/>
     </xs:complexType>
 
     <xs:complexType name="responsesType">


### PR DESCRIPTION
### Jira link (if applicable)
SDT-223 (https://tools.hmcts.net/jira/browse/SDT-223)


### Change description ###
Experimental reorder of responseType attributes in BulkFeedbackResponse.xsd.  This is to establish if it affects the order in which they appear in the XML.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
