### PR TITLE
SDT-223: Remove UnsupportedOperationException from BulkFeedbackEnricher

### DIFF
--- a/interceptors/src/main/java/uk/gov/moj/sdt/interceptors/enricher/BulkFeedbackEnricher.java
+++ b/interceptors/src/main/java/uk/gov/moj/sdt/interceptors/enricher/BulkFeedbackEnricher.java
@@ -209,10 +209,13 @@ public class BulkFeedbackEnricher extends AbstractSdtEnricher {
             if (matcher.find() && !matcher.group(1).equals(REJECTED.getStatus())) {
                 // Use the captured status code to ignore rejected responses which do not need to be enhanced.
                 // We found a response that has not been enriched. Failure to find matching request in outgoing XML.
+
+                // Log this as an error but don't throw UnsupportedOperationException anymore.  The requestId attribute
+                // was not the last attribute in the response tag in SDT, so the UnsupportedOperationException was never
+                // thrown.  Following the refresh of the code however, the requestId is the last attribute, so the
+                // exception is thrown.  Removed exception to ensure same behaviour as SDT.
                 LOGGER.error("Detected unenriched response tag[{}] within bulk feedback response XML.",
                              matcher.group());
-                throw new UnsupportedOperationException("Detected unenriched response tag[" + matcher.group() +
-                                                            "] within bulk feedback response XML.");
             }
 
             if (LOGGER.isDebugEnabled()) {

--- a/interceptors/src/unit-test/java/uk/gov/moj/sdt/interceptors/enricher/BulkFeedbackEnricherTest.java
+++ b/interceptors/src/unit-test/java/uk/gov/moj/sdt/interceptors/enricher/BulkFeedbackEnricherTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -67,6 +68,7 @@ class BulkFeedbackEnricherTest extends AbstractSdtUnitTestBase {
      * Setup for this test.
      */
     @BeforeEach
+    @Override
     public void setUp() {
         // Create enricher to be tested.
         enricher = new BulkFeedbackEnricher();
@@ -240,6 +242,7 @@ class BulkFeedbackEnricherTest extends AbstractSdtUnitTestBase {
      * Test failure to enrich one of the requests in the outgoing XML.
      */
     @Test
+    @Disabled("Disabled following removal of UnsupportedOperationException from enrichXml() method")
     void testUnenrichedResponse() {
         // Create map to hold fake responses from MCOL.
         final Map<String, String> targetApplicationRespMap = new HashMap<>();
@@ -331,12 +334,12 @@ class BulkFeedbackEnricherTest extends AbstractSdtUnitTestBase {
         // Setup the XML to be enriched.
         final String inXml = Utilities.getRawXml("src/unit-test/resources/", "testLargeFeedbackResponse.xml");
 
-        LOGGER.info("Start enrichment of " + targetApplicationRespMap.size() + " responses.");
+        LOGGER.info("Start enrichment of {} responses.", targetApplicationRespMap.size());
 
         // Call the enricher.
         enricher.enrichXml(inXml);
 
-        LOGGER.info("End enrichment of " + targetApplicationRespMap.size() + " responses.");
+        LOGGER.info("End enrichment of {} responses.", targetApplicationRespMap.size());
     }
 
 }


### PR DESCRIPTION
### Jira link (if applicable)
SDT-223 (https://tools.hmcts.net/jira/browse/SDT-223)


### Change description ###
The BulkFeedbackEnricher was intended to throw an UnsupportedOperationException if the response returned for an individual request contained a non-rejected status and no response from MCOL (i.e. the responseDetail tag is empty).  In practise the exception was never thrown because the regular expression used to detect such an occurrence expects the requestId attribute to be the last attribute in the response tag and this was never the case.  Updating the libraries used by SDT has changed the attribute order, so exceptions are being thrown when previously they weren't.  Removed the exception to ensure the same behaviour as before.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
