### PR TITLE
SDT-200: Add "Case Locked" individual request status

### DIFF
--- a/dao-api/src/main/java/uk/gov/moj/sdt/dao/api/IIndividualRequestDao.java
+++ b/dao-api/src/main/java/uk/gov/moj/sdt/dao/api/IIndividualRequestDao.java
@@ -104,4 +104,15 @@ public interface IIndividualRequestDao extends IGenericDao {
      * @throws DataAccessException JPA exception
      */
     long countStaleIndividualRequests(final int minimumAgeInMinutes) throws DataAccessException;
+
+    /**
+     * Returns a list of individual requests that are in the case locked state for more than the specified number
+     * of minutes.  This state occurs when the target application returns a response indicating that the case the
+     * request corresponds to is locked.
+     *
+     * @param minimumAgeInMinutes The minimum number of minutes since an individual request was updated
+     * @return List of individual requests
+     * @throws DataAccessException JPA exception
+     */
+    List<IIndividualRequest> getCaseLockedIndividualRequests(final int minimumAgeInMinutes) throws DataAccessException;
 }

--- a/domain/src/main/java/uk/gov/moj/sdt/domain/IndividualRequest.java
+++ b/domain/src/main/java/uk/gov/moj/sdt/domain/IndividualRequest.java
@@ -25,6 +25,7 @@ import uk.gov.moj.sdt.domain.api.IIndividualRequest;
 import uk.gov.moj.sdt.utils.mbeans.SdtMetricsMBean;
 
 import static uk.gov.moj.sdt.domain.api.IIndividualRequest.IndividualRequestStatus.AWAITING_DATA;
+import static uk.gov.moj.sdt.domain.api.IIndividualRequest.IndividualRequestStatus.CASE_LOCKED;
 import static uk.gov.moj.sdt.domain.api.IIndividualRequest.IndividualRequestStatus.FORWARDED;
 import static uk.gov.moj.sdt.domain.api.IIndividualRequest.IndividualRequestStatus.INITIALLY_ACCEPTED;
 import static uk.gov.moj.sdt.domain.api.IIndividualRequest.IndividualRequestStatus.REJECTED;
@@ -379,6 +380,17 @@ public class IndividualRequest extends AbstractDomainObject implements IIndividu
         // Set the updated date
         this.setUpdatedDate(LocalDateTime.now());
 
+    }
+
+    @Override
+    public void markRequestAsCaseLocked() {
+        setRequestStatus(CASE_LOCKED.getStatus());
+
+        // Reset forwarding attempts
+        setForwardingAttempts(0);
+
+        // Set the updated date
+        setUpdatedDate(LocalDateTime.now());
     }
 
     @Override

--- a/domain/src/main/java/uk/gov/moj/sdt/domain/api/IIndividualRequest.java
+++ b/domain/src/main/java/uk/gov/moj/sdt/domain/api/IIndividualRequest.java
@@ -252,6 +252,12 @@ public interface IIndividualRequest extends IDomainObject {
     void markRequestAsAwaitingData();
 
     /**
+     * This method will mark the individual request object with "Case Locked" status
+     * and set the updated date.
+     */
+    void markRequestAsCaseLocked();
+
+    /**
      * is Enqueueable?.
      *
      * @return true if request can be enqueued else false.
@@ -331,6 +337,11 @@ public interface IIndividualRequest extends IDomainObject {
          * Queued.
          */
         QUEUED("Queued"),
+
+        /**
+         * Case Locked.
+         */
+        CASE_LOCKED("Case Locked"),
 
         /**
          * Queued.

--- a/domain/src/unit-test/java/uk/gov/moj/sdt/domain/IndividualRequestTest.java
+++ b/domain/src/unit-test/java/uk/gov/moj/sdt/domain/IndividualRequestTest.java
@@ -1,6 +1,5 @@
 package uk.gov.moj.sdt.domain;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.moj.sdt.domain.api.IBulkSubmission;
@@ -25,23 +24,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @DisplayName("Writing Individual Request Tests")
 class IndividualRequestTest extends AbstractSdtUnitTestBase {
-    /**
-     * Test subject.
-     */
-    private IIndividualRequest individualRequest;
     private static final String UPDATED_DATE_SHOULD_BE_POPULATED = "Updated date should be populated";
     private static final String FORWARDING_ATTEMPT_COUNT_MESSAGE = "Forwarding attempt count is incorrect";
     private static final String STATUS_IS_INCORRECT_MESSAGE = "Status is incorrect";
     private static final String REQUEST_TYPE_MESSAGE = "Request Type";
 
-    private static final LocalDateTime createdDate = LocalDateTime.now();
+    private static final LocalDateTime CREATED_DATE = LocalDateTime.now();
+
+    /**
+     * Test subject.
+     */
+    private IIndividualRequest individualRequest;
 
     /**
      * Set up test data.
      */
-    @BeforeEach
     @Override
-    public void setUp() {
+    protected void setUpLocalTests() {
         individualRequest = new IndividualRequest();
     }
 
@@ -49,7 +48,7 @@ class IndividualRequestTest extends AbstractSdtUnitTestBase {
     void testIndividualRequestSetters() {
         individualRequest.setId(1L);
         individualRequest.setDeadLetter(true);
-        individualRequest.setCreatedDate(createdDate);
+        individualRequest.setCreatedDate(CREATED_DATE);
         individualRequest.setRequestType(REQUEST_TYPE_MESSAGE);
         individualRequest.setRequestPayload("Request Payload".getBytes());
         individualRequest.setSdtRequestReference("1");
@@ -59,7 +58,7 @@ class IndividualRequestTest extends AbstractSdtUnitTestBase {
 
         assertTrue(individualRequest.isDeadLetter());
         assertEquals(1L, individualRequest.getId());
-        assertEquals(createdDate, individualRequest.getCreatedDate());
+        assertEquals(CREATED_DATE, individualRequest.getCreatedDate());
         assertEquals(REQUEST_TYPE_MESSAGE, individualRequest.getRequestType());
         assertEquals("Request Payload", new String(individualRequest.getRequestPayload(), StandardCharsets.UTF_8));
         assertEquals("1", individualRequest.getSdtRequestReference());
@@ -165,11 +164,24 @@ class IndividualRequestTest extends AbstractSdtUnitTestBase {
     }
 
     @Test
+    @DisplayName("Test mark request as Case Locked")
+    void testMarkRequestAsCaseLocked() {
+        individualRequest.setForwardingAttempts(1);
+
+        individualRequest.markRequestAsCaseLocked();
+
+        assertEquals(IndividualRequestStatus.CASE_LOCKED.getStatus(),
+                     individualRequest.getRequestStatus(),
+                     STATUS_IS_INCORRECT_MESSAGE);
+        assertEquals(0, individualRequest.getForwardingAttempts(), FORWARDING_ATTEMPT_COUNT_MESSAGE);
+        assertNotNull(individualRequest.getUpdatedDate(), UPDATED_DATE_SHOULD_BE_POPULATED);
+    }
+
+    @Test
     @DisplayName("Test Individual Request Reference")
     void testIndividualRequestReference() {
-
         individualRequest.setSdtBulkReference("REF0202");
-        assertEquals("REF0202", individualRequest.getSdtBulkReference(), "reference should be set");
+        assertEquals("REF0202", individualRequest.getSdtBulkReference(), "SDT bulk reference should be set");
         assertNull(individualRequest.getErrorLog(), "Error log should be null");
     }
 
@@ -216,8 +228,10 @@ class IndividualRequestTest extends AbstractSdtUnitTestBase {
         individualRequest.setLineNumber(1);
         individualRequest.populateReferences();
 
-        assertEquals("BULK-REF-0000001", individualRequest.getSdtRequestReference(), "Request reference is incorrect");
-        assertEquals("BULK-REF", individualRequest.getSdtBulkReference(), "Request reference is incorrect");
+        assertEquals("BULK-REF-0000001",
+                     individualRequest.getSdtRequestReference(),
+                     "Request SDT request reference is incorrect");
+        assertEquals("BULK-REF", individualRequest.getSdtBulkReference(), "Request SDT bulk reference is incorrect");
     }
 
 
@@ -232,7 +246,8 @@ class IndividualRequestTest extends AbstractSdtUnitTestBase {
     @DisplayName("Test Request Internal System Error")
     void testIndividualRequestSystemError(){
         individualRequest.setInternalSystemError("Internal System Error");
-        assertEquals("Internal System Error", individualRequest.getInternalSystemError(),"Internal System error should be populated");
+        assertEquals("Internal System Error",
+                     individualRequest.getInternalSystemError(), "Internal System error should be populated");
     }
 
 }


### PR DESCRIPTION
### Jira link
See [SDT-200](https://tools.hmcts.net/jira/browse/SDT-200)

### Change description
Added "Case Locked" status to IndividualRequestStatus enum.

Added markRequestAsCaseLocked() method to IIndividualRequest interface.  Implemented markRequestAsCaseLocked() method on IndividualRequest class.

Added test for markRequestAsCaseLocked() to IndividualRequestTest class.

Tidied up IndividualRequestTest class:
- Corrected order of fields
- Corrected format of created date constant name
- Replaced override of setUp() with setUpLocalTests()
- Altered a few error messages to make it clearer what the cause of the failure is

### Testing done
Added test for new method to IndividualRequestTest class.

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [yes] Does this PR introduce a breaking change
