### PR TITLE
SDT-203: Changed handling of unsupported CMC request types

### DIFF
--- a/utils/src/main/java/uk/gov/moj/sdt/utils/cmc/RequestTypeXmlNodeValidator.java
+++ b/utils/src/main/java/uk/gov/moj/sdt/utils/cmc/RequestTypeXmlNodeValidator.java
@@ -2,7 +2,7 @@ package uk.gov.moj.sdt.utils.cmc;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.moj.sdt.utils.cmc.exception.CMCException;
+import uk.gov.moj.sdt.utils.cmc.exception.CMCUnsupportedRequestTypeException;
 import uk.gov.moj.sdt.utils.cmc.xml.XmlElementValueReader;
 
 import static uk.gov.moj.sdt.utils.cmc.RequestType.BREATHING_SPACE;
@@ -36,8 +36,9 @@ public class RequestTypeXmlNodeValidator {
                                     String xmlNodeName,
                                     boolean throwException) {
         if (isCCDReference(requestPayload, xmlNodeName)) {
-            if (!isValidRequestType(requestType) && throwException) {
-                throw new CMCException(String.format("Request Type: %s not supported", requestType));
+            if (throwException && !isValidRequestType(requestType)) {
+                throw new CMCUnsupportedRequestTypeException(String.format("Request Type %s not supported",
+                                                                           requestType));
             }
             return true;
         }

--- a/utils/src/main/java/uk/gov/moj/sdt/utils/cmc/exception/CMCUnsupportedRequestTypeException.java
+++ b/utils/src/main/java/uk/gov/moj/sdt/utils/cmc/exception/CMCUnsupportedRequestTypeException.java
@@ -1,0 +1,13 @@
+package uk.gov.moj.sdt.utils.cmc.exception;
+
+import java.io.Serial;
+
+public class CMCUnsupportedRequestTypeException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = -4190292439477027658L;
+
+    public CMCUnsupportedRequestTypeException(String message) {
+        super(message);
+    }
+}

--- a/utils/src/unit-test/java/uk/gov/moj/sdt/utils/cmc/RequestTypeXmlNodeValidatorTest.java
+++ b/utils/src/unit-test/java/uk/gov/moj/sdt/utils/cmc/RequestTypeXmlNodeValidatorTest.java
@@ -1,0 +1,197 @@
+package uk.gov.moj.sdt.utils.cmc;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.moj.sdt.utils.AbstractSdtUnitTestBase;
+import uk.gov.moj.sdt.utils.cmc.exception.CMCUnsupportedRequestTypeException;
+import uk.gov.moj.sdt.utils.cmc.xml.XmlElementValueReader;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RequestTypeXmlNodeValidatorTest extends AbstractSdtUnitTestBase {
+
+    private static final String REQUEST_PAYLOAD_CCD_CLAIM_REF = "<claimNumber>1234-1234-1234-1234</claimNumber>";
+    private static final String REQUEST_PAYLOAD_NON_CCD_CLAIM_REF = "<claimNumber>9QZ00005</claimNumber>";
+    private static final String NODE_NAME_CLAIM_NUMBER = "claimNumber";
+    private static final String CCD_CLAIM_REF = "1234-1234-1234-1234";
+    private static final String NON_CCD_CLAIM_REF = "9QZ00005";
+
+    @Mock
+    private CCDReferenceValidator mockCCDReferenceValidator;
+
+    @Mock
+    private XmlElementValueReader mockXmlElementValueReader;
+
+    private RequestTypeXmlNodeValidator requestTypeXmlNodeValidator;
+
+    @Override
+    protected void setUpLocalTests() {
+        requestTypeXmlNodeValidator =
+                new RequestTypeXmlNodeValidator(mockCCDReferenceValidator, mockXmlElementValueReader);
+    }
+
+    @Test
+    void testIsCmcClaimRequest() {
+        assertTrue(requestTypeXmlNodeValidator.isCMCClaimRequest(RequestType.CLAIM.getType(), true),
+                   "The combination of CLAIM and true should be flagged as a CMC claim request");
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidCmcClaimRequest")
+    void testNotIsCmcClaimRequest(RequestType requestType, Boolean readyForAlternateService) {
+        String reqType = requestType == null ? null : requestType.getType();
+        assertFalse(requestTypeXmlNodeValidator.isCMCClaimRequest(reqType, readyForAlternateService),
+                    "This combination should not be flagged as a CMC claim request");
+    }
+
+    @Test
+    void testIsCmcRequestType() {
+        when(mockXmlElementValueReader.getElementValue(REQUEST_PAYLOAD_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER))
+                .thenReturn(CCD_CLAIM_REF);
+        when(mockCCDReferenceValidator.isValidCCDReference(CCD_CLAIM_REF)).thenReturn(true);
+
+        assertTrue(requestTypeXmlNodeValidator.isCMCRequestType(RequestType.JUDGMENT.getType(),
+                                                                REQUEST_PAYLOAD_CCD_CLAIM_REF,
+                                                                NODE_NAME_CLAIM_NUMBER,
+                                                                false),
+                   "This request type with a CCD claim ref should be flagged as a CMC request type");
+
+        verify(mockXmlElementValueReader).getElementValue(REQUEST_PAYLOAD_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER);
+        verify(mockCCDReferenceValidator).isValidCCDReference(CCD_CLAIM_REF);
+    }
+
+    @Test
+    void testNotIsCmcRequestType() {
+        when(mockXmlElementValueReader.getElementValue(REQUEST_PAYLOAD_NON_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER))
+                .thenReturn(NON_CCD_CLAIM_REF);
+        when(mockCCDReferenceValidator.isValidCCDReference(NON_CCD_CLAIM_REF)).thenReturn(false);
+
+        assertFalse(requestTypeXmlNodeValidator.isCMCRequestType(RequestType.JUDGMENT.getType(),
+                                                                 REQUEST_PAYLOAD_NON_CCD_CLAIM_REF,
+                                                                 NODE_NAME_CLAIM_NUMBER,
+                                                                 false),
+                    "This request type with a non-CCD claim ref should not be flagged as a CMC request type");
+
+        verify(mockXmlElementValueReader).getElementValue(REQUEST_PAYLOAD_NON_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER);
+        verify(mockCCDReferenceValidator).isValidCCDReference(NON_CCD_CLAIM_REF);
+    }
+
+    @ParameterizedTest
+    @MethodSource("validCmcRequestTypes")
+    void testIsCmcRequestTypeValidType(String requestType) {
+        when(mockXmlElementValueReader.getElementValue(REQUEST_PAYLOAD_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER))
+                .thenReturn(CCD_CLAIM_REF);
+        when(mockCCDReferenceValidator.isValidCCDReference(CCD_CLAIM_REF)).thenReturn(true);
+
+        assertTrue(requestTypeXmlNodeValidator.isCMCRequestType(requestType,
+                                                                REQUEST_PAYLOAD_CCD_CLAIM_REF,
+                                                                NODE_NAME_CLAIM_NUMBER,
+                                                                true),
+                   "This request type with a CCD claim ref should be flagged as a CMC request type");
+
+        verify(mockXmlElementValueReader).getElementValue(REQUEST_PAYLOAD_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER);
+        verify(mockCCDReferenceValidator).isValidCCDReference(CCD_CLAIM_REF);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"mcolSetAside"})
+    @NullSource
+    void testIsCmcRequestTypeInvalidType(String requestType) {
+        when(mockXmlElementValueReader.getElementValue(REQUEST_PAYLOAD_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER))
+                .thenReturn(CCD_CLAIM_REF);
+        when(mockCCDReferenceValidator.isValidCCDReference(CCD_CLAIM_REF)).thenReturn(true);
+
+        CMCUnsupportedRequestTypeException exception =
+                assertThrows(CMCUnsupportedRequestTypeException.class,
+                             () -> requestTypeXmlNodeValidator.isCMCRequestType(requestType,
+                                                                                REQUEST_PAYLOAD_CCD_CLAIM_REF,
+                                                                                NODE_NAME_CLAIM_NUMBER,
+                                                                                true),
+                             "A CMCUnsupportedRequestTypeException should be thrown for this request type"
+        );
+        assertEquals("Request Type " + requestType + " not supported",
+                     exception.getMessage(),
+                     "CMCUnsupportedRequestTypeException has unexpected message");
+
+        verify(mockXmlElementValueReader).getElementValue(REQUEST_PAYLOAD_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER);
+        verify(mockCCDReferenceValidator).isValidCCDReference(CCD_CLAIM_REF);
+    }
+
+    @ParameterizedTest
+    @MethodSource("validCmcRequestTypes")
+    void testIsValidRequestType(String requestType) {
+        assertTrue(requestTypeXmlNodeValidator.isValidRequestType(requestType),
+                   "This request type should be a valid request type");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"mcolSetAside"})
+    @NullSource
+    void testNotIsValidRequestType(String requestType) {
+        assertFalse(requestTypeXmlNodeValidator.isValidRequestType(requestType),
+                    "This request type should not be a valid request type");
+    }
+
+    @Test
+    void testIsCCDReference() {
+        when(mockXmlElementValueReader.getElementValue(REQUEST_PAYLOAD_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER))
+                .thenReturn(CCD_CLAIM_REF);
+        when(mockCCDReferenceValidator.isValidCCDReference(CCD_CLAIM_REF)).thenReturn(true);
+
+        assertTrue(requestTypeXmlNodeValidator.isCCDReference(REQUEST_PAYLOAD_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER),
+                   "Claim reference should be a CCD reference");
+
+        verify(mockXmlElementValueReader).getElementValue(REQUEST_PAYLOAD_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER);
+        verify(mockCCDReferenceValidator).isValidCCDReference(CCD_CLAIM_REF);
+    }
+
+    @Test
+    void testNotIsCCDReference() {
+        when(mockXmlElementValueReader.getElementValue(REQUEST_PAYLOAD_NON_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER))
+                .thenReturn(NON_CCD_CLAIM_REF);
+        when(mockCCDReferenceValidator.isValidCCDReference(NON_CCD_CLAIM_REF)).thenReturn(false);
+
+        assertFalse(requestTypeXmlNodeValidator.isCCDReference(REQUEST_PAYLOAD_NON_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER),
+                    "Claim reference should not be a CCD reference");
+
+        verify(mockXmlElementValueReader).getElementValue(REQUEST_PAYLOAD_NON_CCD_CLAIM_REF, NODE_NAME_CLAIM_NUMBER);
+        verify(mockCCDReferenceValidator).isValidCCDReference(NON_CCD_CLAIM_REF);
+    }
+
+    private static Stream<Arguments> validCmcRequestTypes() {
+        return Stream.of(
+                arguments("mcolBreathingSpace"),
+                arguments("mcolClaimStatusUpdate"),
+                arguments("mcolJudgment"),
+                arguments("mcolJudgmentWarrant"),
+                arguments("mcolWarrant")
+        );
+    }
+
+    private static Stream<Arguments> invalidCmcClaimRequest() {
+        return Stream.of(
+                arguments(RequestType.JUDGMENT, true),
+                arguments(RequestType.JUDGMENT, false),
+                arguments(null, true),
+                arguments(null, false),
+                arguments(RequestType.JUDGMENT, null),
+                arguments(null, null)
+        );
+    }
+}


### PR DESCRIPTION
### Jira link

See [SDT-203](https://tools.hmcts.net/jira/browse/SDT-203)

### Change description

Added new CMCUnsupportedRequestTypeException class.

Updated RequestTypeXmlNodeValidator.isCMCRequestType() method to throw CMCUnsupportedRequestTypeException instead of CMCException.

Added test class for RequestTypeXmlNodeValidator.

### Testing done

Added test class for RequestTypeXmlNodeValidator

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
