### PR TITLE
SDT-200: Add "Case Locked" to individual status code type enumeration

### DIFF
--- a/producers-api/src/main/resources/xsd/RootXSDs/Base.xsd
+++ b/producers-api/src/main/resources/xsd/RootXSDs/Base.xsd
@@ -241,6 +241,7 @@
             <xs:enumeration value="Awaiting Data" />
             <xs:enumeration value="Accepted" />
             <xs:enumeration value="Rejected" />
+            <xs:enumeration value="Case Locked" />
         </xs:restriction>
     </xs:simpleType>
 

--- a/producers-api/src/unit-test/java/uk/gov/moj/sdt/producers/api/BulkFeedbackResponseXsdTest.java
+++ b/producers-api/src/unit-test/java/uk/gov/moj/sdt/producers/api/BulkFeedbackResponseXsdTest.java
@@ -86,6 +86,7 @@ class BulkFeedbackResponseXsdTest extends AbstractSdtXmlTestBase {
     /**
      * Tests that expected errors are reported for incorrect format of fields.
      */
+    @Test
     void testInvalidXmlIncorrectFormat() {
         final String condition = "IncorrectFormat";
         final String xmlPath = XML_DIR + XSD_NAME + condition + AbstractSdtXmlTestBase.XML_FILE_SUFFIX;

--- a/producers-api/src/unit-test/resources/xml/validation/RequestBulkFeedback/BulkFeedbackResponseIncorrectFormatErrorMessages.txt
+++ b/producers-api/src/unit-test/resources/xml/validation/RequestBulkFeedback/BulkFeedbackResponseIncorrectFormatErrorMessages.txt
@@ -23,7 +23,7 @@ cvc-maxLength-valid: Value '1234' with length = '4' is not facet-valid with resp
 cvc-type.3.1.3: The value '1234' of element 'rdns:enforcingCourtCode' is not valid.
 cvc-maxLength-valid: Value '12345678901234567890123456789012345678901' with length = '41' is not facet-valid with respect to maxLength '40' for type 'courtNameType'.
 cvc-type.3.1.3: The value '12345678901234567890123456789012345678901' of element 'rdns:enforcingCourtName' is not valid.
-cvc-enumeration-valid: Value 'UNKNOWN' is not facet-valid with respect to enumeration '[Received, Forwarded, Initially Accepted, Awaiting Data, Accepted, Rejected]'. It must be a value from the enumeration.
+cvc-enumeration-valid: Value 'UNKNOWN' is not facet-valid with respect to enumeration '[Received, Forwarded, Initially Accepted, Awaiting Data, Accepted, Rejected, Case Locked]'. It must be a value from the enumeration.
 cvc-attribute.3: The value 'UNKNOWN' of attribute 'code' on element 'tns:status' is not valid with respect to its type, 'individualStatusCodeType'.
 cvc-maxLength-valid: Value '123456789012345678901234567890123' with length = '33' is not facet-valid with respect to maxLength '32' for type '#AnonType_codeerrorType'.
 cvc-type.3.1.3: The value '123456789012345678901234567890123' of element 'base:code' is not valid.


### PR DESCRIPTION
### Jira link

See [SDT-200](https://tools.hmcts.net/jira/browse/SDT-200)

### Change description

Added "Case Locked" to enumerations for individualStatusCodeType in Base.xsd.

Reworked BulkFeedbackTransformerTest.testTransformDomainToJaxb() to test all individual request statuses.  Corrected assertions where domain object was being checked instead of Jaxb.  Tidied up class.

Reinstated BulkFeedbackResponseXsdTest.testInvalidXmlIncorrectFormat() test by adding test annotation.  Appears to have been missed when test class was refactored in 2015.

Added "Case Locked" to cvc-enumeration-valid error message in BulkFeedbackResponseIncorrectFormatErrorMessages.txt

Removed code that set up individual requests in BulkRequestTransformerTest.transformDomainToJaxb().  Transformer doesn't do anything with them so it wasn't needed.  Tidied up class.

### Testing done

Updated test classes

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
