### PR TITLE
SDT-241: Add vulnerability fields to Claim.xsd

### DIFF
--- a/producers-api/src/main/resources/xsd/RootXSDs/Claim.xsd
+++ b/producers-api/src/main/resources/xsd/RootXSDs/Claim.xsd
@@ -90,6 +90,20 @@
             <xs:element name="address" type="base:addressType" />
         </xs:sequence>
     </xs:complexType>
+
+    <xs:complexType name="claimantWitnessVulnerableType">
+        <xs:sequence>
+            <xs:element name="isVulnerable" type="xs:boolean" />
+            <xs:element name="vulnerableDetails" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="base:sdtNonBlankStringType">
+                        <xs:minLength value="1" />
+                        <xs:maxLength value="150" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
     
 	<xs:complexType name="claimType">
         <xs:sequence>
@@ -104,6 +118,7 @@
 			<xs:element name="claimAmount" type="xs:unsignedLong"/>
 			<xs:element name="solicitorCost" type="xs:unsignedLong" minOccurs="0" />
             <xs:element name="particulars" type="tns:particularsType" minOccurs="1" maxOccurs="24"/>
+            <xs:element name="claimantWitnessVulnerable" type="tns:claimantWitnessVulnerableType" minOccurs="0"/>
             <xs:element name="sotSignature" type="base:sotSignatureType"/>
         </xs:sequence>
 	</xs:complexType>

--- a/producers-api/src/unit-test/java/uk/gov/moj/sdt/producers/api/ClaimXsdTest.java
+++ b/producers-api/src/unit-test/java/uk/gov/moj/sdt/producers/api/ClaimXsdTest.java
@@ -85,7 +85,7 @@ class ClaimXsdTest extends AbstractSdtXmlTestBase {
     }
 
     /**
-     * Tests that vulnerability details field is optional.
+     * Tests that vulnerable details field is optional.
      */
     @Test
     void testValidXmlOptionalVulnerableDetails() {
@@ -131,6 +131,9 @@ class ClaimXsdTest extends AbstractSdtXmlTestBase {
         this.validateXsd (xmlPath, XSD_PATH, errorFilePathname);
     }
 
+    /**
+     * Tests that expected errors are reported for a blank vulnerable details field.
+     */
     @Test
     void testInvalidXmlVulnerableDetailsBlank() {
         final String condition = "VulnerableDetailsBlank";

--- a/producers-api/src/unit-test/java/uk/gov/moj/sdt/producers/api/ClaimXsdTest.java
+++ b/producers-api/src/unit-test/java/uk/gov/moj/sdt/producers/api/ClaimXsdTest.java
@@ -72,6 +72,30 @@ class ClaimXsdTest extends AbstractSdtXmlTestBase {
     }
 
     /**
+     * Tests that the claimant/witness vulnerable section is optional.
+     * Note that this test will need to be removed and the mandatory
+     * missing test updated when the section is made mandatory.
+     */
+    @Test
+    void testValidXmlOptionalClaimantWitnessVulnerable() {
+        final String condition = "OptionalClaimantWitnessVulnerable";
+        final String xmlPath = XML_DIR + XSD_NAME + condition + AbstractSdtXmlTestBase.XML_FILE_SUFFIX;
+
+        this.validateXsd(xmlPath, XSD_PATH, null);
+    }
+
+    /**
+     * Tests that vulnerability details field is optional.
+     */
+    @Test
+    void testValidXmlOptionalVulnerableDetails() {
+        final String condition = "OptionalVulnerableDetails";
+        final String xmlPath = XML_DIR + XSD_NAME + condition + AbstractSdtXmlTestBase.XML_FILE_SUFFIX;
+
+        this.validateXsd(xmlPath, XSD_PATH, null);
+    }
+
+    /**
      * Tests that expected errors are reported for missing mandatory fields.
      */
     @Test
@@ -84,6 +108,18 @@ class ClaimXsdTest extends AbstractSdtXmlTestBase {
     }
 
     /**
+     * Tests that expected errors are reported for missing mandatory isVulnerable field.
+     */
+    @Test
+    void testInvalidXmlMandatoryIsVulnerableMissing() {
+        final String condition = "MandatoryIsVulnerableMissing";
+        final String xmlPath = XML_DIR + XSD_NAME + condition + AbstractSdtXmlTestBase.XML_FILE_SUFFIX;
+        final String errorFilePathname = XML_DIR + XSD_NAME + condition + AbstractSdtXmlTestBase.ERROR_FILE_SUFFIX;
+
+        this.validateXsd(xmlPath, XSD_PATH, errorFilePathname);
+    }
+
+    /**
      * Tests that expected errors are reported for incorrect format of fields.
      */
     @Test
@@ -93,5 +129,14 @@ class ClaimXsdTest extends AbstractSdtXmlTestBase {
         final String errorFilePathname = XML_DIR + XSD_NAME + condition + AbstractSdtXmlTestBase.ERROR_FILE_SUFFIX;
 
         this.validateXsd (xmlPath, XSD_PATH, errorFilePathname);
+    }
+
+    @Test
+    void testInvalidXmlVulnerableDetailsBlank() {
+        final String condition = "VulnerableDetailsBlank";
+        final String xmlPath = XML_DIR + XSD_NAME + condition + AbstractSdtXmlTestBase.XML_FILE_SUFFIX;
+        final String errorFilePathname = XML_DIR + XSD_NAME + condition + AbstractSdtXmlTestBase.ERROR_FILE_SUFFIX;
+
+        this.validateXsd(xmlPath, XSD_PATH, errorFilePathname);
     }
 }

--- a/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimIncorrectFormat.xml
+++ b/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimIncorrectFormat.xml
@@ -39,6 +39,10 @@
   <tns:claimAmount>-1</tns:claimAmount>
   <tns:solicitorCost>-1</tns:solicitorCost>
   <tns:particulars>1234567890123456789012345678901234567890123456</tns:particulars>
+  <tns:claimantWitnessVulnerable>
+    <tns:isVulnerable></tns:isVulnerable>
+    <tns:vulnerableDetails>1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901</tns:vulnerableDetails>
+  </tns:claimantWitnessVulnerable>
   <tns:sotSignature>
     <base:flag></base:flag>
     <base:name>123456789012345678901234567890</base:name>

--- a/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimIncorrectFormatErrorMessages.txt
+++ b/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimIncorrectFormatErrorMessages.txt
@@ -43,3 +43,7 @@ cvc-type.3.1.3: The value '   ' of element 'base:line1' is not valid.
 cvc-type.3.1.3: The value '' of element 'base:line2' is not valid.
 cvc-pattern-valid: Value '' is not facet-valid with respect to pattern '(\s*[^\s]\s*)+' for type 'nonBlankLineType'.
 cvc-complex-type.2.4.a: Invalid content was found starting with element '{"http://ws.sdt.moj.gov.uk/2013/mcol/ClaimSchema":line3}'. One of '{"http://ws.sdt.moj.gov.uk/2013/mcol/ClaimSchema":line2}' is expected.
+cvc-datatype-valid.1.2.1: '' is not a valid value for 'boolean'.
+cvc-type.3.1.3: The value '' of element 'tns:isVulnerable' is not valid.
+cvc-maxLength-valid: Value '1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901' with length = '151' is not facet-valid with respect to maxLength '150' for type '#AnonType_vulnerableDetailsclaimantWitnessVulnerableType'.
+cvc-type.3.1.3: The value '1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901' of element 'tns:vulnerableDetails' is not valid.

--- a/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimMandatoryIsVulnerableMissing.xml
+++ b/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimMandatoryIsVulnerableMissing.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tns:mcolClaim xmlns:base="http://ws.sdt.moj.gov.uk/2013/sdt/BaseSchema" xmlns:tns="http://ws.sdt.moj.gov.uk/2013/mcol/ClaimSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ws.sdt.moj.gov.uk/2013/mcol/ClaimSchema ../../../../../main/resources/xsd/RootXSDs/Claim.xsd ">
+    <tns:claimant>
+        <tns:name>tns name</tns:name>
+        <tns:address>
+            <tns:line1>tns line1</tns:line1>
+            <tns:line2>tns line2</tns:line2>
+            <tns:line3>tns line3</tns:line3>
+            <tns:line4>tns line4</tns:line4>
+            <tns:postcode>FL23 2SD</tns:postcode>
+        </tns:address>
+    </tns:claimant>
+    <tns:defendant1>
+        <tns:name>tns name</tns:name>
+        <tns:address>
+            <base:line1>base line1</base:line1>
+            <base:line2>base line2</base:line2>
+            <base:line3>base line3</base:line3>
+            <base:line4>base line4</base:line4>
+            <base:postcode>FL23 2SD</base:postcode>
+        </tns:address>
+    </tns:defendant1>
+    <tns:sendParticularsSeparately>true</tns:sendParticularsSeparately>
+    <tns:reserveRightToClaimInterest>false</tns:reserveRightToClaimInterest>
+    <tns:claimAmount>0</tns:claimAmount>
+    <tns:solicitorCost>0</tns:solicitorCost>
+    <tns:particulars>tns particulars</tns:particulars>
+    <tns:claimantWitnessVulnerable>
+        <tns:vulnerableDetails>1234567890</tns:vulnerableDetails>
+    </tns:claimantWitnessVulnerable>
+    <tns:sotSignature>
+        <base:flag>true</base:flag>
+        <base:name>123456789012345678901234567890</base:name>
+    </tns:sotSignature>
+</tns:mcolClaim>

--- a/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimMandatoryIsVulnerableMissingErrorMessages.txt
+++ b/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimMandatoryIsVulnerableMissingErrorMessages.txt
@@ -1,0 +1,1 @@
+cvc-complex-type.2.4.a: Invalid content was found starting with element '{"http://ws.sdt.moj.gov.uk/2013/mcol/ClaimSchema":vulnerableDetails}'. One of '{"http://ws.sdt.moj.gov.uk/2013/mcol/ClaimSchema":isVulnerable}' is expected.

--- a/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimOptionalClaimantWitnessVulnerable.xml
+++ b/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimOptionalClaimantWitnessVulnerable.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tns:mcolClaim xmlns:base="http://ws.sdt.moj.gov.uk/2013/sdt/BaseSchema" xmlns:tns="http://ws.sdt.moj.gov.uk/2013/mcol/ClaimSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ws.sdt.moj.gov.uk/2013/mcol/ClaimSchema ../../../../../main/resources/xsd/RootXSDs/Claim.xsd ">
+    <tns:claimant>
+        <tns:name>tns name</tns:name>
+        <tns:address>
+            <tns:line1>tns line1</tns:line1>
+            <tns:line2>tns line2</tns:line2>
+        </tns:address>
+    </tns:claimant>
+    <tns:defendant1>
+        <tns:name>tns name</tns:name>
+        <tns:address>
+            <base:line1>base line1</base:line1>
+            <base:line2>base line2</base:line2>
+            <base:postcode>FL23 2SD</base:postcode>
+        </tns:address>
+    </tns:defendant1>
+    <tns:sendParticularsSeparately>true</tns:sendParticularsSeparately>
+    <tns:reserveRightToClaimInterest>false</tns:reserveRightToClaimInterest>
+    <tns:claimAmount>0</tns:claimAmount>
+    <tns:solicitorCost>0</tns:solicitorCost>
+    <tns:particulars>tns particulars</tns:particulars>
+    <tns:sotSignature>
+        <base:flag>true</base:flag>
+        <base:name>123456789012345678901234567890</base:name>
+    </tns:sotSignature>
+</tns:mcolClaim>

--- a/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimOptionalVulnerableDetails.xml
+++ b/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimOptionalVulnerableDetails.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tns:mcolClaim xmlns:base="http://ws.sdt.moj.gov.uk/2013/sdt/BaseSchema" xmlns:tns="http://ws.sdt.moj.gov.uk/2013/mcol/ClaimSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ws.sdt.moj.gov.uk/2013/mcol/ClaimSchema ../../../../../main/resources/xsd/RootXSDs/Claim.xsd ">
+    <tns:claimant>
+        <tns:name>tns name</tns:name>
+        <tns:address>
+            <tns:line1>tns line1</tns:line1>
+            <tns:line2>tns line2</tns:line2>
+            <tns:line3>tns line3</tns:line3>
+            <tns:line4>tns line4</tns:line4>
+            <tns:postcode>FL23 2SD</tns:postcode>
+        </tns:address>
+    </tns:claimant>
+    <tns:defendant1>
+        <tns:name>tns name</tns:name>
+        <tns:address>
+            <base:line1>base line1</base:line1>
+            <base:line2>base line2</base:line2>
+            <base:line3>base line3</base:line3>
+            <base:line4>base line4</base:line4>
+            <base:postcode>FL23 2SD</base:postcode>
+        </tns:address>
+    </tns:defendant1>
+    <tns:sendParticularsSeparately>true</tns:sendParticularsSeparately>
+    <tns:reserveRightToClaimInterest>false</tns:reserveRightToClaimInterest>
+    <tns:claimAmount>0</tns:claimAmount>
+    <tns:solicitorCost>0</tns:solicitorCost>
+    <tns:particulars>tns particulars</tns:particulars>
+    <tns:claimantWitnessVulnerable>
+        <tns:isVulnerable>false</tns:isVulnerable>
+    </tns:claimantWitnessVulnerable>
+    <tns:sotSignature>
+        <base:flag>true</base:flag>
+        <base:name>123456789012345678901234567890</base:name>
+    </tns:sotSignature>
+</tns:mcolClaim>

--- a/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimValid.xml
+++ b/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimValid.xml
@@ -50,6 +50,10 @@
   <tns:claimAmount>0</tns:claimAmount>
   <tns:solicitorCost>0</tns:solicitorCost>
   <tns:particulars>tns particulars</tns:particulars>
+  <tns:claimantWitnessVulnerable>
+    <tns:isVulnerable>true</tns:isVulnerable>
+    <tns:vulnerableDetails>123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890</tns:vulnerableDetails>
+  </tns:claimantWitnessVulnerable>
   <tns:sotSignature>
     <base:flag>true</base:flag>
     <base:name>123456789012345678901234567890</base:name>

--- a/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimVulnerableDetailsBlank.xml
+++ b/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimVulnerableDetailsBlank.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tns:mcolClaim xmlns:base="http://ws.sdt.moj.gov.uk/2013/sdt/BaseSchema" xmlns:tns="http://ws.sdt.moj.gov.uk/2013/mcol/ClaimSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ws.sdt.moj.gov.uk/2013/mcol/ClaimSchema ../../../../../main/resources/xsd/RootXSDs/Claim.xsd ">
+    <tns:claimant>
+        <tns:name>tns name</tns:name>
+        <tns:address>
+            <tns:line1>tns line1</tns:line1>
+            <tns:line2>tns line2</tns:line2>
+        </tns:address>
+    </tns:claimant>
+    <tns:defendant1>
+        <tns:name>tns name</tns:name>
+        <tns:address>
+            <base:line1>base line1</base:line1>
+            <base:line2>base line2</base:line2>
+            <base:postcode>FL23 2SD</base:postcode>
+        </tns:address>
+    </tns:defendant1>
+    <tns:sendParticularsSeparately>true</tns:sendParticularsSeparately>
+    <tns:reserveRightToClaimInterest>false</tns:reserveRightToClaimInterest>
+    <tns:claimAmount>0</tns:claimAmount>
+    <tns:solicitorCost>0</tns:solicitorCost>
+    <tns:particulars>tns particulars</tns:particulars>
+    <tns:claimantWitnessVulnerable>
+        <tns:isVulnerable>true</tns:isVulnerable>
+        <tns:vulnerableDetails> </tns:vulnerableDetails>
+    </tns:claimantWitnessVulnerable>
+    <tns:sotSignature>
+        <base:flag>true</base:flag>
+        <base:name>123456789012345678901234567890</base:name>
+    </tns:sotSignature>
+</tns:mcolClaim>

--- a/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimVulnerableDetailsBlankErrorMessages.txt
+++ b/producers-api/src/unit-test/resources/xml/validation/mcolType/ClaimVulnerableDetailsBlankErrorMessages.txt
@@ -1,0 +1,2 @@
+cvc-pattern-valid: Value ' ' is not facet-valid with respect to pattern '(\s*[^\s]\s*)+' for type '#AnonType_vulnerableDetailsclaimantWitnessVulnerableType'.
+cvc-type.3.1.3: The value ' ' of element 'tns:vulnerableDetails' is not valid.


### PR DESCRIPTION
### Jira link
See [SDT-241](https://tools.hmcts.net/jira/browse/SDT-241)

### Change description
- Added claimantWitnessVulnerableType to Claim.xsd.  This type consists of two fields, isVulnerable and vulnerableDetails.  Added optional claimantWitnessVulnerable element to claimType type.
- Updated ClaimIncorrectFormat test to include invalid values for isVulnerable and vulnerableDetails fields.
- Updated ClaimValid.xml to include valid values for isVulnerable and vulnerableDetails fields.
- Added tests to ClaimXsdTest to check that claimantWitnessVulnerable section is optional and the vulnerableDetails field is optional.  Also added tests to check that XSD validation fails if isVulnerable field is missing and if vulnerableDetails field is blank.

### Testing done
Updated unit tests to include checks for new fields.  See description section for details.

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
